### PR TITLE
Remove obsolete admin-ui-classic-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "minimum-stability": "dev",
     "require": {
         "open-dxp/opendxp": "*",
-        "open-dxp/admin-ui-classic-bundle": "*",
         "symfony/dotenv": "^7.3",
         "symfony/runtime": "^7.3"
     },


### PR DESCRIPTION
As of `v1.1.0` this is required by `open-dxp/opendxp`