### PR TITLE
add missing symfony/amqp-messenger as composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "open-dxp/opendxp": "*",
+        "symfony/amqp-messenger": "^7.4",
         "symfony/dotenv": "^7.4",
         "symfony/runtime": "^7.4"
     },


### PR DESCRIPTION
Thought a bit, if this should be in the core package or in skeleton, but since skeleton seems to have the config (https://github.com/open-dxp/skeleton/blob/1.x/.docker/messenger.yaml), i guess it's better placed here.

**What is this about?**
when trying to delete a document in a fresh skeleton install, it fails because of missing amqp-messenger

**Following error is not expected:**
Could not delete item
No transport supports Messenger DSN "amqp://rabbitmq:5672/%2f/opendxp_core". Run "composer require symfony/amqp-messenger" to install AMQP transport.

**Why:**
amqp-messenger is configured in skeleton, but not installed.

**Fix:**
composer require symfony/amqp-messenger

**Note:**
My local install also has following untracked files/ folders:
	.htaccess
	cache/
	config/packages/messenger.yaml (empty file)
	config/reference.php (always gets recreated)
i guess messenger.yaml is coming from the docker volume mount, so to keep the mr clean, i'm not touching .gitignore - but it might be a good idea to ignore some files or the cache folder =).